### PR TITLE
valutazione costi formazione per utenti finali

### DIFF
--- a/acquisizione-software/macro-fase-3-analisi-delle-altre-soluzioni.rst
+++ b/acquisizione-software/macro-fase-3-analisi-delle-altre-soluzioni.rst
@@ -49,8 +49,10 @@ seguenti criteri:
    presente nel Marketplace Cloud di AgID;
 -  eventuali costi necessari all’integrazione della soluzione con i
    sistemi già in uso presso l’amministrazione;
--  eventuali costi per la formazione del personale destinato alla
-   gestione e amministrazione della soluzione esaminata;
+-  eventuali costi per la formazione del personale, considerando sia
+   quelli necessari per l’addestramento dei soggetti destinati alla
+   gestione della soluzione sia quelli per il suo utilizzo da parte
+   degli utenti finali;
 -  calcolo del TCO e sua congruità rispetto alla disponibilità di
    bilancio determinata nella precedente Macro fase 1.
 


### PR DESCRIPTION
Nella valutazione delle soluzioni riusabili è contemplato il costo di formazione degli operatori e anche degli utenti finali, in quella delle soluzioni proprietarie solo il costo di formazione degli operatori.
Il frammento di testo è stato integrato a partire [da qui](https://github.com/agid/lg-acquisizione-e-riuso-software-per-pa-docs/blob/master/acquisizione-software/macro-fase-2-analisi-delle-soluzioni-a-riuso-delle-pa-e-delle-soluzioni-open-source.rst).