### PR TITLE
Indipendenza da particolari paradigmi di programmazione

### DIFF
--- a/attachments/allegato-e-guida-alla-modifica-di-software-open-source-preso-a-riuso-o-di-terzi.rst
+++ b/attachments/allegato-e-guida-alla-modifica-di-software-open-source-preso-a-riuso-o-di-terzi.rst
@@ -49,8 +49,10 @@ indispensabile, preferendo invece i seguenti interventi:
    senza modificare il *core* (ad esempio, nel caso di un Content
    Management System);
 
--  laddove sia possibile estendere le classi esistenti senza modificarne
-   il codice è necessario seguire questa strada.
+-  laddove sia possibile riutilizzare il codice esistente senza
+   modificarlo (ad esempio, mediante l’ereditarietà nel caso della
+   programmazione orientata agli oggetti) è necessario seguire questa
+   strada.
 
 Qualora non sia possibile realizzare tutte le funzionalità mediante i
 sopra descritti meccanismi di estensione, ma sia necessario modificare


### PR DESCRIPTION
Le classi appartengono alla sola programmazione ad oggetti, pertanto è necessario utilizzare una locuzione generica che esprima il concetto di riutilizzo ed estensione del codice.