### PR TITLE
Sostituzione di Wikipedia con Google Traduttore in esempio di SaaS

### DIFF
--- a/premessa/glossario.rst
+++ b/premessa/glossario.rst
@@ -69,8 +69,9 @@ SaaS
     Software as a Service. Indica una modalità di distribuzione del
     software che non viene installato sulle postazioni degli operatori,
     ma che avviene attraverso l’accesso remoto a un server, per esempio
-    collegandosi con un browser ad un indirizzo. Wikipedia, per esempio,
-    è un software distribuito in modalità Software as a Service.
+    collegandosi con un browser ad un indirizzo. Google Traduttore, per
+    esempio, è un software distribuito in modalità Software as a
+    Service.
 
 Software proprietario
     Software che ha restrizioni sul suo utilizzo, sulla sua modifica,


### PR DESCRIPTION
Come scritto in "[Quel server in realtà a chi serve?](https://www.gnu.org/philosophy/who-does-that-server-really-serve.it.html)", «se modificate delle voci di Wikipedia, non state compiendo un'attività informatica personale, ma state collaborando alle attività informatiche di Wikipedia, realizzate sui server controllati da Wikipedia stessa».

Si configura invece come SaaS, ad esempio, il ricorso ad una wiki farm su cui ospitare un proprio wiki, in quanto attività non riguardante il gestore del server.

Google Traduttore è suggerito quale esempio certo di SaaS, non trattandosi principalmente di un servizio di comunicazione, e data anche la disponibilità di programmi equivalenti eseguibili direttamente dagli utenti sui propri dispositivi.