### PR TITLE
Fix: modificato riferimento ad allegato

### DIFF
--- a/attachments/allegato-c-guida-alla-manutenzione-di-software-open-source.rst
+++ b/attachments/allegato-c-guida-alla-manutenzione-di-software-open-source.rst
@@ -49,8 +49,7 @@ controllo di versione prescelto (MAY).
 
 Qualora invece l'Amministrazione non sia già titolare di un repository
 per il *software* oggetto della manutenzione, dovrà procedere a crearne
-uno seguendo le indicazioni della *Guida alla modifica di *software* open
-source di terzi*.
+uno seguendo le indicazioni della *Guida alla presa in riuso di software open source*.
 
 Obblighi relativi alla manutenzione di *software* per il quale l'Amministrazione disponga già di un repository
 --------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Corretto perché ho fatto l'ipotesi che la "Guida alla modifica di software open source di terzi" è in realtà un riferimento all'Allegato D: "Guida alla presa in riuso di software open source". Ho modificato anche la formattazione portando tutto in italic. @alranel @libremente